### PR TITLE
Add support for npm publish --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can set any or all of the following input parameters:
 |`registry`      |string  |no        |https://registry.npmjs.org/ |The NPM registry URL to use
 |`package`       |string  |no        |./package.json              |The path of your package.json file
 |`check-version` |boolean |no        |true                        |Only publish to NPM if the version number in `package.json` differs from the latest on NPM
+|`dry-run` |boolean |no        |false                        |Run NPM publish with the `--dry-run` flag to prevent publication.
 
 
 
@@ -193,6 +194,8 @@ options:
   --version, -v       Print the version number
 
   --help, -h          Show help
+
+  --dry-run           Pass the `--dry-run` flag to NPM
 
 package_path          The absolute or relative path of the NPM package to publish.
                       Can be a directory path, or the path of a package.json file.

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
     required: false
     default: "true"
 
+  dry-run:
+    description: If true, run with the --dry-run flag
+    required: false
+    default: "false"
+
 outputs:
   type:
     description: The type of version change that occurred ("none", "major", "minor", "patch", etc.)

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -18,14 +18,18 @@ async function main(): Promise<void> {
       registry: getInput("registry", { required: true }),
       package: getInput("package", { required: true }),
       checkVersion: getInput("check-version", { required: true }).toLowerCase() === "true",
+      dryRun: getInput("dry-run").toLowerCase() === "true",
       debug: debugHandler,
     };
 
-    // Puglish to NPM
+    // Publish to NPM
     let results = await npmPublish(options);
 
     if (results.type === "none") {
       console.log(`\n📦 ${results.package} v${results.version} is already published to NPM`);
+    }
+    else if (results.type === "dry-run") {
+      console.log(`\n📦 ${results.package} v${results.version} successfully built but not published to NPM`);
     }
     else {
       console.log(`\n📦 Successfully published ${results.package} v${results.version} to NPM`);

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
     if (results.type === "none") {
       console.log(`\n📦 ${results.package} v${results.version} is already published to NPM`);
     }
-    else if (results.type === "dry-run") {
+    else if (results.dryRun) {
       console.log(`\n📦 ${results.package} v${results.version} successfully built but not published to NPM`);
     }
     else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,7 +37,7 @@ export async function main(args: string[]): Promise<void> {
         if (results.type === "none") {
           console.log(`\n📦 ${results.package} v${results.version} is already published to NPM`);
         }
-        else if (results.type === "dry-run") {
+        else if (results.dryRun) {
           console.log(`\n📦 ${results.package} v${results.version} successfully built but not published to NPM`);
         }
         else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,9 @@ export async function main(args: string[]): Promise<void> {
         if (results.type === "none") {
           console.log(`\n📦 ${results.package} v${results.version} is already published to NPM`);
         }
+        else if (results.type === "dry-run") {
+          console.log(`\n📦 ${results.package} v${results.version} successfully built but not published to NPM`);
+        }
         else {
           console.log(`\n📦 Successfully published ${results.package} v${results.version} to NPM`);
         }

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -28,6 +28,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
         { name: "quiet", alias: "q", type: Boolean },
         { name: "version", alias: "v", type: Boolean },
         { name: "help", alias: "h", type: Boolean },
+        { name: "dry-run", type: Boolean, defaultOption: false }
       ],
       { argv }
     );
@@ -49,6 +50,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
         package: args.package as string,
         debug: args.debug ? console.debug : undefined,
         quiet: args.quiet as boolean,
+        dryRun: args["dry-run"] as boolean
       }
     };
 

--- a/src/normalize-options.ts
+++ b/src/normalize-options.ts
@@ -10,6 +10,7 @@ export interface NormalizedOptions {
   registry: URL;
   package: string;
   checkVersion: boolean;
+  dryRun: boolean;
   quiet: boolean;
   debug: Debug;
 }
@@ -26,6 +27,7 @@ export function normalizeOptions(options: Options): NormalizedOptions {
     registry: registryURL || new URL("https://registry.npmjs.org/"),
     package: options.package || "package.json",
     checkVersion: options.checkVersion === undefined ? true : Boolean(options.checkVersion),
+    dryRun: options.dryRun || false,
     quiet: options.quiet || false,
     debug: options.debug || (() => undefined),
   };

--- a/src/npm-publish.ts
+++ b/src/npm-publish.ts
@@ -25,9 +25,10 @@ export async function npmPublish(opts: Options = {}): Promise<Results> {
 
   let results: Results = {
     package: manifest.name,
-    type: options.dryRun ? "dry-run" : (diff || "none"),
+    type: diff || "none",
     version: manifest.version.raw,
     oldVersion: publishedVersion.raw,
+    dryRun: options.dryRun
   };
 
   options.debug("OUTPUT:", results);

--- a/src/npm-publish.ts
+++ b/src/npm-publish.ts
@@ -25,7 +25,7 @@ export async function npmPublish(opts: Options = {}): Promise<Results> {
 
   let results: Results = {
     package: manifest.name,
-    type: diff || "none",
+    type: options.dryRun ? "dry-run" : (diff || "none"),
     version: manifest.version.raw,
     oldVersion: publishedVersion.raw,
   };

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -25,7 +25,7 @@ export const npm = {
 
       options.debug(`Running command: npm view ${name} version`);
 
-      // Run NPM to get the latest published versiono of the package
+      // Run NPM to get the latest published version of the package
       let { stdout } = await ezSpawn.async("npm", ["view", name, "version"], { env });
       let version = stdout.trim();
 
@@ -60,8 +60,10 @@ export const npm = {
 
       options.debug("Running command: npm publish", { stdio, cwd, env });
 
+      let command = options.dryRun ? ["publish", "--dry-run"] : ["publish"];
+
       // Run NPM to publish the package
-      await ezSpawn.async("npm", ["publish"], { cwd, stdio, env });
+      await ezSpawn.async("npm", command, { cwd, stdio, env });
     }
     catch (error) {
       throw ono(error, `Unable to publish ${name} v${version} to NPM.`);

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,6 +32,15 @@ export interface Options {
   checkVersion?: boolean;
 
   /**
+   * If true, run npm publish with the --dry-run flag
+   * so that the package is not published. Used for
+   * testing workflows.
+   *
+   * Defaults to `false`
+   */
+  dryRun?: boolean;
+
+  /**
    * Suppress console output from NPM and npm-publish.
    *
    * Defaults to `false`

--- a/src/results.ts
+++ b/src/results.ts
@@ -9,7 +9,7 @@ export interface Results {
   /**
    * The type of version change that occurred
    */
-  type: ReleaseType | "none";
+  type: ReleaseType | "none" | "dry-run";
 
   /**
    * The name of the NPM package that was published

--- a/src/results.ts
+++ b/src/results.ts
@@ -3,13 +3,13 @@ import { ReleaseType } from "semver";
 export { ReleaseType };
 
 /**
- * Results of the `publish
+ * Results of the publish
  */
 export interface Results {
   /**
    * The type of version change that occurred
    */
-  type: ReleaseType | "none" | "dry-run";
+  type: ReleaseType | "none";
 
   /**
    * The name of the NPM package that was published
@@ -25,4 +25,9 @@ export interface Results {
    * The version number that was previously published to NPM
    */
   oldVersion: string;
+
+  /**
+   * Whether this was a dry run (not published to NPM)
+   */
+  dryRun: boolean;
 }

--- a/test/specs/action/success.spec.js
+++ b/test/specs/action/success.spec.js
@@ -265,4 +265,49 @@ describe("GitHub Action - success tests", () => {
     npm.assert.ran(4);
   });
 
+  it("should not publish a package if dryRun is true", () => {
+    files.create([
+      { path: "workspace/package.json", contents: { name: "my-lib", version: "1.1.0" }},
+      { path: "home/.npmrc", contents: "This is my NPM config.\nThere are many like it,\nbut this one is mine." },
+    ]);
+
+    npm.mock({
+      args: ["config", "get", "userconfig"],
+      stdout: `${paths.npmrc}${EOL}`,
+    });
+
+    npm.mock({
+      args: ["view", "my-lib", "version"],
+      stdout: `1.0.0${EOL}`,
+    });
+
+    npm.mock({
+      args: ["config", "get", "userconfig"],
+      stdout: `${paths.npmrc}${EOL}`,
+    });
+
+    npm.mock({
+      args: ["publish", "--dry-run"],
+      env: { INPUT_TOKEN: "my-secret-token" },
+      stdout: `my-lib 1.1.0${EOL}`,
+    });
+
+    let cli = exec.action({
+      env: {
+        INPUT_TOKEN: "my-secret-token",
+        "INPUT_DRY-RUN": "true"
+      }
+    });
+
+    expect(cli).to.have.stderr("");
+    expect(cli).stdout.to.include("::set-output name=type::dry-run");
+    expect(cli).stdout.to.include("::set-output name=version::1.1.0");
+    expect(cli).stdout.to.include("::set-output name=old-version::1.0.0");
+    expect(cli).stdout.to.include("my-lib 1.1.0");
+    expect(cli).stdout.to.include("📦 my-lib v1.1.0 successfully built but not published to NPM");
+    expect(cli).to.have.exitCode(0);
+
+    npm.assert.ran(4);
+  });
+
 });

--- a/test/specs/action/success.spec.js
+++ b/test/specs/action/success.spec.js
@@ -300,7 +300,7 @@ describe("GitHub Action - success tests", () => {
     });
 
     expect(cli).to.have.stderr("");
-    expect(cli).stdout.to.include("::set-output name=type::dry-run");
+    expect(cli).stdout.to.include("::set-output name=type::minor");
     expect(cli).stdout.to.include("::set-output name=version::1.1.0");
     expect(cli).stdout.to.include("::set-output name=old-version::1.0.0");
     expect(cli).stdout.to.include("my-lib 1.1.0");

--- a/test/specs/cli/args.spec.js
+++ b/test/specs/cli/args.spec.js
@@ -139,4 +139,12 @@ describe("CLI - argument tests", () => {
       npm.assert.ran(0);
     });
   });
+
+
+  describe("npm-publish --dry-run", () => {
+    it("should call npm publish with the --dry-run flag", () => {
+      let cli = exec.cli("--dry-run");
+      expect(cli.args).to.include("--dry-run");
+    });
+  });
 });

--- a/test/specs/cli/success.spec.js
+++ b/test/specs/cli/success.spec.js
@@ -266,4 +266,38 @@ describe("CLI - success tests", () => {
     npm.assert.ran(4);
   });
 
+  it("should not publish the package if publish is called with --dry-run", () => {
+    files.create([
+      { path: "workspace/package.json", contents: { name: "my-lib", version: "1.1.0" }},
+    ]);
+
+    npm.mock({
+      args: ["config", "get", "userconfig"],
+      stdout: `${paths.npmrc}${EOL}`,
+    });
+
+    npm.mock({
+      args: ["view", "my-lib", "version"],
+      stdout: `1.0.0${EOL}`,
+    });
+
+    npm.mock({
+      args: ["config", "get", "userconfig"],
+      stdout: `${paths.npmrc}${EOL}`,
+    });
+
+    npm.mock({
+      args: ["publish", "--dry-run"],
+      stdout: `my-lib 1.1.0${EOL}`,
+    });
+
+    let cli = exec.cli("--dry-run");
+
+    expect(cli).to.have.stderr("");
+    expect(cli).stdout.to.include("my-lib 1.1.0");
+    expect(cli).stdout.to.include("📦 my-lib v1.1.0 successfully built but not published to NPM");
+    expect(cli).to.have.exitCode(0);
+
+    npm.assert.ran(4);
+  });
 });

--- a/test/specs/lib/success.spec.js
+++ b/test/specs/lib/success.spec.js
@@ -51,7 +51,8 @@ describe("NPM package - success tests", () => {
       type: "major",
       package: "my-lib",
       version: "2.0.0",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -83,7 +84,8 @@ describe("NPM package - success tests", () => {
       type: "none",
       package: "my-lib",
       version: "1.0.0",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -129,7 +131,8 @@ describe("NPM package - success tests", () => {
       type: "prerelease",
       package: "my-lib",
       version: "1.0.0-beta.1",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -172,7 +175,8 @@ describe("NPM package - success tests", () => {
       type: "minor",
       package: "my-lib",
       version: "1.1.0",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -231,7 +235,8 @@ describe("NPM package - success tests", () => {
       type: "patch",
       package: "my-lib",
       version: "1.0.1",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -284,7 +289,8 @@ describe("NPM package - success tests", () => {
       type: "prerelease",
       package: "my-lib",
       version: "1.0.0-beta",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: false
     });
 
     files.assert.contents("home/.npmrc",
@@ -295,7 +301,7 @@ describe("NPM package - success tests", () => {
     npm.assert.ran(4);
   });
 
-  it("should return a type of dry-run when called with --dry-run", async () => {
+  it("results.dryRun should be true when called with --dry-run", async () => {
     files.create([
       { path: "workspace/package.json", contents: { name: "my-lib", version: "1.1.0" }},
     ]);
@@ -327,10 +333,11 @@ describe("NPM package - success tests", () => {
     });
 
     expect(results).to.deep.equal({
-      type: "dry-run",
+      type: "minor",
       package: "my-lib",
       version: "1.1.0",
-      oldVersion: "1.0.0"
+      oldVersion: "1.0.0",
+      dryRun: true
     });
 
     files.assert.contents("home/.npmrc",


### PR DESCRIPTION
From #6: Add an extra Option/command line argument to optionally run npm publish with the --dry-run flag enabled to prevent
actual publishing. Intended for use in testing workflows. This option/argument defaults to false.

Wasn't sure if build files should be committed, so I left them out for now.