### PR TITLE
Update npm-publish.ts

### DIFF
--- a/src/npm-publish.ts
+++ b/src/npm-publish.ts
@@ -13,15 +13,22 @@ export async function npmPublish(opts: Options = {}): Promise<Results> {
 
   // Get the old and new version numbers
   let manifest = await readManifest(options.package, options.debug);
-  let publishedVersion = await npm.getLatestVersion(manifest.name, options);
-
-  // Determine if/how the version has changed
-  let diff = semver.diff(manifest.version, publishedVersion);
-
-  if (diff || !options.checkVersion) {
+  
+  //If checkVersion is false then publish.
+  if (!options.checkVersion) {
     // Publish the new version to NPM
     await npm.publish(manifest, options);
-  }
+  }else {
+    let publishedVersion = await npm.getLatestVersion(manifest.name, options);
+
+    // Determine if/how the version has changed
+    let diff = semver.diff(manifest.version, publishedVersion);
+
+    if (diff) {
+      // Publish the new version to NPM
+      await npm.publish(manifest, options);
+    }
+  }    
 
   let results: Results = {
     package: manifest.name,

--- a/src/npm-publish.ts
+++ b/src/npm-publish.ts
@@ -13,12 +13,9 @@ export async function npmPublish(opts: Options = {}): Promise<Results> {
 
   // Get the old and new version numbers
   let manifest = await readManifest(options.package, options.debug);
-  
-  //If checkVersion is false then publish.
-  if (!options.checkVersion) {
-    // Publish the new version to NPM
-    await npm.publish(manifest, options);
-  }else {
+
+  // If checkVersion is false then publish.
+  if (options.checkVersion) {
     let publishedVersion = await npm.getLatestVersion(manifest.name, options);
 
     // Determine if/how the version has changed
@@ -28,13 +25,25 @@ export async function npmPublish(opts: Options = {}): Promise<Results> {
       // Publish the new version to NPM
       await npm.publish(manifest, options);
     }
-  }    
 
+    let results: Results = {
+      package: manifest.name,
+      type: diff || "none",
+      version: manifest.version.raw,
+      oldVersion: publishedVersion.raw,
+      dryRun: options.dryRun
+    };
+
+    options.debug("OUTPUT:", results);
+    return results;
+  }
+
+  await npm.publish(manifest, options);
   let results: Results = {
     package: manifest.name,
-    type: diff || "none",
+    type: "none",
     version: manifest.version.raw,
-    oldVersion: publishedVersion.raw,
+    oldVersion: "",
     dryRun: options.dryRun
   };
 


### PR DESCRIPTION
Fix #11 
This change to fix error if there are not any packages in the NPM as it is giving error on that function getLatestVersion and if the checkVersion flag set to false then no use to get version and compare.