### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 12
-      - run: npm install
+      - run: npm ci
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1
         with:


### PR DESCRIPTION
Seems like the point of `npm ci` is exactly this case?