### PR TITLE
Upgrade semver

### DIFF
--- a/dist/node_modules/semver/README.md
+++ b/dist/node_modules/semver/README.md
@@ -110,6 +110,9 @@ Options:
 -l --loose
         Interpret versions and ranges loosely
 
+-n <0|1>
+        This is the base to be used for the prerelease identifier.
+
 -p --include-prerelease
         Always include prerelease versions in range matching
 
@@ -229,6 +232,24 @@ Which then can be used to increment further:
 
 ```bash
 $ semver 1.2.4-beta.0 -i prerelease
+1.2.4-beta.1
+```
+
+#### Prerelease Identifier Base
+
+The method `.inc` takes an optional parameter 'identifierBase' string
+that will let you let your prerelease number as zero-based or one-based.
+If you do not specify this parameter, it will default to zero-based.
+
+```javascript
+semver.inc('1.2.3', 'prerelease', 'beta', '1')
+// '1.2.4-beta.1'
+```
+
+command-line example:
+
+```bash
+$ semver 1.2.3 -i prerelease --preid beta -n 1
 1.2.4-beta.1
 ```
 
@@ -513,6 +534,40 @@ ex.
 * `s.clean('      2.1.5   ')`: `'2.1.5'`
 * `s.clean('~1.0.0')`: `null`
 
+## Constants
+
+As a convenience, helper constants are exported to provide information about what `node-semver` supports:
+
+### `RELEASE_TYPES`
+
+- major
+- premajor
+- minor
+- preminor
+- patch
+- prepatch
+- prerelease
+
+```
+const semver = require('semver');
+
+if (semver.RELEASE_TYPES.includes(arbitraryUserInput)) {
+  console.log('This is a valid release type!');
+} else {
+  console.warn('This is NOT a valid release type!');
+}
+```
+
+### `SEMVER_SPEC_VERSION`
+
+2.0.0
+
+```
+const semver = require('semver');
+
+console.log('We are currently using the semver specification version:', semver.SEMVER_SPEC_VERSION);
+```
+
 ## Exported Modules
 
 <!--
@@ -566,3 +621,4 @@ The following modules are available:
 * `require('semver/ranges/outside')`
 * `require('semver/ranges/to-comparators')`
 * `require('semver/ranges/valid')`
+

--- a/dist/node_modules/semver/bin/semver.js
+++ b/dist/node_modules/semver/bin/semver.js
@@ -23,7 +23,10 @@ let rtl = false
 
 let identifier
 
+let identifierBase
+
 const semver = require('../')
+const parseOptions = require('../internal/parse-options')
 
 let reverse = false
 
@@ -71,6 +74,9 @@ const main = () => {
       case '-r': case '--range':
         range.push(argv.shift())
         break
+      case '-n':
+        identifierBase = argv.shift()
+        break
       case '-c': case '--coerce':
         coerce = true
         break
@@ -88,7 +94,7 @@ const main = () => {
     }
   }
 
-  options = { loose: loose, includePrerelease: includePrerelease, rtl: rtl }
+  options = parseOptions({ loose, includePrerelease, rtl })
 
   versions = versions.map((v) => {
     return coerce ? (semver.coerce(v, options) || { version: v }).version : v
@@ -127,7 +133,7 @@ const success = () => {
   }).map((v) => {
     return semver.clean(v, options)
   }).map((v) => {
-    return inc ? semver.inc(v, inc, options, identifier) : v
+    return inc ? semver.inc(v, inc, options, identifier, identifierBase) : v
   }).forEach((v, i, _) => {
     console.log(v)
   })

--- a/dist/node_modules/semver/classes/comparator.js
+++ b/dist/node_modules/semver/classes/comparator.js
@@ -78,13 +78,6 @@ class Comparator {
       throw new TypeError('a Comparator is required')
     }
 
-    if (!options || typeof options !== 'object') {
-      options = {
-        loose: !!options,
-        includePrerelease: false,
-      }
-    }
-
     if (this.operator === '') {
       if (this.value === '') {
         return true
@@ -97,32 +90,43 @@ class Comparator {
       return new Range(this.value, options).test(comp.semver)
     }
 
-    const sameDirectionIncreasing =
-      (this.operator === '>=' || this.operator === '>') &&
-      (comp.operator === '>=' || comp.operator === '>')
-    const sameDirectionDecreasing =
-      (this.operator === '<=' || this.operator === '<') &&
-      (comp.operator === '<=' || comp.operator === '<')
-    const sameSemVer = this.semver.version === comp.semver.version
-    const differentDirectionsInclusive =
-      (this.operator === '>=' || this.operator === '<=') &&
-      (comp.operator === '>=' || comp.operator === '<=')
-    const oppositeDirectionsLessThan =
-      cmp(this.semver, '<', comp.semver, options) &&
-      (this.operator === '>=' || this.operator === '>') &&
-        (comp.operator === '<=' || comp.operator === '<')
-    const oppositeDirectionsGreaterThan =
-      cmp(this.semver, '>', comp.semver, options) &&
-      (this.operator === '<=' || this.operator === '<') &&
-        (comp.operator === '>=' || comp.operator === '>')
+    options = parseOptions(options)
 
-    return (
-      sameDirectionIncreasing ||
-      sameDirectionDecreasing ||
-      (sameSemVer && differentDirectionsInclusive) ||
-      oppositeDirectionsLessThan ||
-      oppositeDirectionsGreaterThan
-    )
+    // Special cases where nothing can possibly be lower
+    if (options.includePrerelease &&
+      (this.value === '<0.0.0-0' || comp.value === '<0.0.0-0')) {
+      return false
+    }
+    if (!options.includePrerelease &&
+      (this.value.startsWith('<0.0.0') || comp.value.startsWith('<0.0.0'))) {
+      return false
+    }
+
+    // Same direction increasing (> or >=)
+    if (this.operator.startsWith('>') && comp.operator.startsWith('>')) {
+      return true
+    }
+    // Same direction decreasing (< or <=)
+    if (this.operator.startsWith('<') && comp.operator.startsWith('<')) {
+      return true
+    }
+    // same SemVer and both sides are inclusive (<= or >=)
+    if (
+      (this.semver.version === comp.semver.version) &&
+      this.operator.includes('=') && comp.operator.includes('=')) {
+      return true
+    }
+    // opposite directions less than
+    if (cmp(this.semver, '<', comp.semver, options) &&
+      this.operator.startsWith('>') && comp.operator.startsWith('<')) {
+      return true
+    }
+    // opposite directions greater than
+    if (cmp(this.semver, '>', comp.semver, options) &&
+      this.operator.startsWith('<') && comp.operator.startsWith('>')) {
+      return true
+    }
+    return false
   }
 }
 

--- a/dist/node_modules/semver/classes/range.js
+++ b/dist/node_modules/semver/classes/range.js
@@ -81,8 +81,10 @@ class Range {
 
     // memoize range parsing for performance.
     // this is a very hot path, and fully deterministic.
-    const memoOpts = Object.keys(this.options).join(',')
-    const memoKey = `parseRange:${memoOpts}:${range}`
+    const memoOpts =
+      (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) |
+      (this.options.loose && FLAG_LOOSE)
+    const memoKey = memoOpts + ':' + range
     const cached = cache.get(memoKey)
     if (cached) {
       return cached
@@ -190,6 +192,7 @@ class Range {
     return false
   }
 }
+
 module.exports = Range
 
 const LRU = require('lru-cache')
@@ -206,6 +209,7 @@ const {
   tildeTrimReplace,
   caretTrimReplace,
 } = require('../internal/re')
+const { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = require('../internal/constants')
 
 const isNullSet = c => c.value === '<0.0.0-0'
 const isAny = c => c.value === ''
@@ -252,6 +256,7 @@ const isX = id => !id || id.toLowerCase() === 'x' || id === '*'
 // ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0 <1.3.0-0
 // ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0-0
 // ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0-0
+// ~0.0.1 --> >=0.0.1 <0.1.0-0
 const replaceTildes = (comp, options) =>
   comp.trim().split(/\s+/).map((c) => {
     return replaceTilde(c, options)
@@ -291,6 +296,8 @@ const replaceTilde = (comp, options) => {
 // ^1.2, ^1.2.x --> >=1.2.0 <2.0.0-0
 // ^1.2.3 --> >=1.2.3 <2.0.0-0
 // ^1.2.0 --> >=1.2.0 <2.0.0-0
+// ^0.0.1 --> >=0.0.1 <0.0.2-0
+// ^0.1.0 --> >=0.1.0 <0.2.0-0
 const replaceCarets = (comp, options) =>
   comp.trim().split(/\s+/).map((c) => {
     return replaceCaret(c, options)

--- a/dist/node_modules/semver/classes/semver.js
+++ b/dist/node_modules/semver/classes/semver.js
@@ -175,36 +175,36 @@ class SemVer {
 
   // preminor will bump the version up to the next minor release, and immediately
   // down to pre-release. premajor and prepatch work the same way.
-  inc (release, identifier) {
+  inc (release, identifier, identifierBase) {
     switch (release) {
       case 'premajor':
         this.prerelease.length = 0
         this.patch = 0
         this.minor = 0
         this.major++
-        this.inc('pre', identifier)
+        this.inc('pre', identifier, identifierBase)
         break
       case 'preminor':
         this.prerelease.length = 0
         this.patch = 0
         this.minor++
-        this.inc('pre', identifier)
+        this.inc('pre', identifier, identifierBase)
         break
       case 'prepatch':
         // If this is already a prerelease, it will bump to the next version
         // drop any prereleases that might already exist, since they are not
         // relevant at this point.
         this.prerelease.length = 0
-        this.inc('patch', identifier)
-        this.inc('pre', identifier)
+        this.inc('patch', identifier, identifierBase)
+        this.inc('pre', identifier, identifierBase)
         break
       // If the input is a non-prerelease version, this acts the same as
       // prepatch.
       case 'prerelease':
         if (this.prerelease.length === 0) {
-          this.inc('patch', identifier)
+          this.inc('patch', identifier, identifierBase)
         }
-        this.inc('pre', identifier)
+        this.inc('pre', identifier, identifierBase)
         break
 
       case 'major':
@@ -263,14 +263,15 @@ class SemVer {
           }
         }
         if (identifier) {
+          const base = Number(identifierBase) ? 1 : 0
           // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
           // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
           if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
             if (isNaN(this.prerelease[1])) {
-              this.prerelease = [identifier, 0]
+              this.prerelease = [identifier, base]
             }
           } else {
-            this.prerelease = [identifier, 0]
+            this.prerelease = [identifier, base]
           }
         }
         break

--- a/dist/node_modules/semver/functions/diff.js
+++ b/dist/node_modules/semver/functions/diff.js
@@ -2,19 +2,35 @@ const parse = require('./parse')
 const eq = require('./eq')
 
 const diff = (version1, version2) => {
-  if (eq(version1, version2)) {
+  const v1 = parse(version1)
+  const v2 = parse(version2)
+  if (eq(v1, v2)) {
     return null
   } else {
-    const v1 = parse(version1)
-    const v2 = parse(version2)
     const hasPre = v1.prerelease.length || v2.prerelease.length
     const prefix = hasPre ? 'pre' : ''
     const defaultResult = hasPre ? 'prerelease' : ''
-    for (const key in v1) {
-      if (key === 'major' || key === 'minor' || key === 'patch') {
-        if (v1[key] !== v2[key]) {
-          return prefix + key
-        }
+
+    if (v1.major !== v2.major) {
+      return prefix + 'major'
+    }
+    if (v1.minor !== v2.minor) {
+      return prefix + 'minor'
+    }
+
+    if (v1.patch !== v2.patch) {
+      return prefix + 'patch'
+    }
+
+    if (!v1.prerelease.length || !v2.prerelease.length) {
+      if (v1.patch) {
+        return 'patch'
+      }
+      if (v1.minor) {
+        return 'minor'
+      }
+      if (v1.major) {
+        return 'major'
       }
     }
     return defaultResult // may be undefined

--- a/dist/node_modules/semver/functions/inc.js
+++ b/dist/node_modules/semver/functions/inc.js
@@ -1,7 +1,8 @@
 const SemVer = require('../classes/semver')
 
-const inc = (version, release, options, identifier) => {
+const inc = (version, release, options, identifier, identifierBase) => {
   if (typeof (options) === 'string') {
+    identifierBase = identifier
     identifier = options
     options = undefined
   }
@@ -10,7 +11,7 @@ const inc = (version, release, options, identifier) => {
     return new SemVer(
       version instanceof SemVer ? version.version : version,
       options
-    ).inc(release, identifier).version
+    ).inc(release, identifier, identifierBase).version
   } catch (er) {
     return null
   }

--- a/dist/node_modules/semver/functions/parse.js
+++ b/dist/node_modules/semver/functions/parse.js
@@ -1,11 +1,6 @@
 const { MAX_LENGTH } = require('../internal/constants')
-const { re, t } = require('../internal/re')
 const SemVer = require('../classes/semver')
-
-const parseOptions = require('../internal/parse-options')
 const parse = (version, options) => {
-  options = parseOptions(options)
-
   if (version instanceof SemVer) {
     return version
   }
@@ -15,11 +10,6 @@ const parse = (version, options) => {
   }
 
   if (version.length > MAX_LENGTH) {
-    return null
-  }
-
-  const r = options.loose ? re[t.LOOSE] : re[t.FULL]
-  if (!r.test(version)) {
     return null
   }
 

--- a/dist/node_modules/semver/index.js
+++ b/dist/node_modules/semver/index.js
@@ -1,48 +1,89 @@
 // just pre-load all the stuff that index.js lazily exports
 const internalRe = require('./internal/re')
+const constants = require('./internal/constants')
+const SemVer = require('./classes/semver')
+const identifiers = require('./internal/identifiers')
+const parse = require('./functions/parse')
+const valid = require('./functions/valid')
+const clean = require('./functions/clean')
+const inc = require('./functions/inc')
+const diff = require('./functions/diff')
+const major = require('./functions/major')
+const minor = require('./functions/minor')
+const patch = require('./functions/patch')
+const prerelease = require('./functions/prerelease')
+const compare = require('./functions/compare')
+const rcompare = require('./functions/rcompare')
+const compareLoose = require('./functions/compare-loose')
+const compareBuild = require('./functions/compare-build')
+const sort = require('./functions/sort')
+const rsort = require('./functions/rsort')
+const gt = require('./functions/gt')
+const lt = require('./functions/lt')
+const eq = require('./functions/eq')
+const neq = require('./functions/neq')
+const gte = require('./functions/gte')
+const lte = require('./functions/lte')
+const cmp = require('./functions/cmp')
+const coerce = require('./functions/coerce')
+const Comparator = require('./classes/comparator')
+const Range = require('./classes/range')
+const satisfies = require('./functions/satisfies')
+const toComparators = require('./ranges/to-comparators')
+const maxSatisfying = require('./ranges/max-satisfying')
+const minSatisfying = require('./ranges/min-satisfying')
+const minVersion = require('./ranges/min-version')
+const validRange = require('./ranges/valid')
+const outside = require('./ranges/outside')
+const gtr = require('./ranges/gtr')
+const ltr = require('./ranges/ltr')
+const intersects = require('./ranges/intersects')
+const simplifyRange = require('./ranges/simplify')
+const subset = require('./ranges/subset')
 module.exports = {
+  parse,
+  valid,
+  clean,
+  inc,
+  diff,
+  major,
+  minor,
+  patch,
+  prerelease,
+  compare,
+  rcompare,
+  compareLoose,
+  compareBuild,
+  sort,
+  rsort,
+  gt,
+  lt,
+  eq,
+  neq,
+  gte,
+  lte,
+  cmp,
+  coerce,
+  Comparator,
+  Range,
+  satisfies,
+  toComparators,
+  maxSatisfying,
+  minSatisfying,
+  minVersion,
+  validRange,
+  outside,
+  gtr,
+  ltr,
+  intersects,
+  simplifyRange,
+  subset,
+  SemVer,
   re: internalRe.re,
   src: internalRe.src,
   tokens: internalRe.t,
-  SEMVER_SPEC_VERSION: require('./internal/constants').SEMVER_SPEC_VERSION,
-  SemVer: require('./classes/semver'),
-  compareIdentifiers: require('./internal/identifiers').compareIdentifiers,
-  rcompareIdentifiers: require('./internal/identifiers').rcompareIdentifiers,
-  parse: require('./functions/parse'),
-  valid: require('./functions/valid'),
-  clean: require('./functions/clean'),
-  inc: require('./functions/inc'),
-  diff: require('./functions/diff'),
-  major: require('./functions/major'),
-  minor: require('./functions/minor'),
-  patch: require('./functions/patch'),
-  prerelease: require('./functions/prerelease'),
-  compare: require('./functions/compare'),
-  rcompare: require('./functions/rcompare'),
-  compareLoose: require('./functions/compare-loose'),
-  compareBuild: require('./functions/compare-build'),
-  sort: require('./functions/sort'),
-  rsort: require('./functions/rsort'),
-  gt: require('./functions/gt'),
-  lt: require('./functions/lt'),
-  eq: require('./functions/eq'),
-  neq: require('./functions/neq'),
-  gte: require('./functions/gte'),
-  lte: require('./functions/lte'),
-  cmp: require('./functions/cmp'),
-  coerce: require('./functions/coerce'),
-  Comparator: require('./classes/comparator'),
-  Range: require('./classes/range'),
-  satisfies: require('./functions/satisfies'),
-  toComparators: require('./ranges/to-comparators'),
-  maxSatisfying: require('./ranges/max-satisfying'),
-  minSatisfying: require('./ranges/min-satisfying'),
-  minVersion: require('./ranges/min-version'),
-  validRange: require('./ranges/valid'),
-  outside: require('./ranges/outside'),
-  gtr: require('./ranges/gtr'),
-  ltr: require('./ranges/ltr'),
-  intersects: require('./ranges/intersects'),
-  simplifyRange: require('./ranges/simplify'),
-  subset: require('./ranges/subset'),
+  SEMVER_SPEC_VERSION: constants.SEMVER_SPEC_VERSION,
+  RELEASE_TYPES: constants.RELEASE_TYPES,
+  compareIdentifiers: identifiers.compareIdentifiers,
+  rcompareIdentifiers: identifiers.rcompareIdentifiers,
 }

--- a/dist/node_modules/semver/internal/constants.js
+++ b/dist/node_modules/semver/internal/constants.js
@@ -9,9 +9,22 @@ const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
 // Max safe segment length for coercion.
 const MAX_SAFE_COMPONENT_LENGTH = 16
 
+const RELEASE_TYPES = [
+  'major',
+  'premajor',
+  'minor',
+  'preminor',
+  'patch',
+  'prepatch',
+  'prerelease',
+]
+
 module.exports = {
-  SEMVER_SPEC_VERSION,
   MAX_LENGTH,
-  MAX_SAFE_INTEGER,
   MAX_SAFE_COMPONENT_LENGTH,
+  MAX_SAFE_INTEGER,
+  RELEASE_TYPES,
+  SEMVER_SPEC_VERSION,
+  FLAG_INCLUDE_PRERELEASE: 0b001,
+  FLAG_LOOSE: 0b010,
 }

--- a/dist/node_modules/semver/internal/parse-options.js
+++ b/dist/node_modules/semver/internal/parse-options.js
@@ -1,11 +1,15 @@
-// parse out just the options we care about so we always get a consistent
-// obj with keys in a consistent order.
-const opts = ['includePrerelease', 'loose', 'rtl']
-const parseOptions = options =>
-  !options ? {}
-  : typeof options !== 'object' ? { loose: true }
-  : opts.filter(k => options[k]).reduce((o, k) => {
-    o[k] = true
-    return o
-  }, {})
+// parse out just the options we care about
+const looseOption = Object.freeze({ loose: true })
+const emptyOpts = Object.freeze({ })
+const parseOptions = options => {
+  if (!options) {
+    return emptyOpts
+  }
+
+  if (typeof options !== 'object') {
+    return looseOption
+  }
+
+  return options
+}
 module.exports = parseOptions

--- a/dist/node_modules/semver/package.json
+++ b/dist/node_modules/semver/package.json
@@ -1,24 +1,20 @@
 {
   "name": "semver",
-  "version": "7.3.7",
+  "version": "7.4.0",
   "description": "The semantic version parser used by npm.",
   "main": "index.js",
   "scripts": {
     "test": "tap",
     "snap": "tap",
-    "preversion": "npm test",
-    "postversion": "npm publish",
-    "postpublish": "git push origin --follow-tags",
     "lint": "eslint \"**/*.js\"",
     "postlint": "template-oss-check",
     "lintfix": "npm run lint -- --fix",
-    "prepublishOnly": "git push origin --follow-tags",
     "posttest": "npm run lint",
     "template-oss-apply": "template-oss-apply --force"
   },
   "devDependencies": {
-    "@npmcli/eslint-config": "^3.0.1",
-    "@npmcli/template-oss": "3.3.2",
+    "@npmcli/eslint-config": "^4.0.0",
+    "@npmcli/template-oss": "4.13.0",
     "tap": "^16.0.0"
   },
   "license": "ISC",
@@ -31,6 +27,7 @@
   },
   "files": [
     "bin/",
+    "lib/",
     "classes/",
     "functions/",
     "internal/",
@@ -41,7 +38,11 @@
   ],
   "tap": {
     "check-coverage": true,
-    "coverage-map": "map.js"
+    "coverage-map": "map.js",
+    "nyc-arg": [
+      "--exclude",
+      "tap-snapshots/**"
+    ]
   },
   "engines": {
     "node": ">=10"
@@ -52,17 +53,18 @@
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "3.3.2",
+    "version": "4.13.0",
     "engines": ">=10",
     "ciVersions": [
       "10.0.0",
       "10.x",
       "12.x",
       "14.x",
-      "16.x"
+      "16.x",
+      "18.x"
     ],
+    "npmSpec": "8",
     "distPaths": [
-      "bin/",
       "classes/",
       "functions/",
       "internal/",
@@ -70,6 +72,16 @@
       "index.js",
       "preload.js",
       "range.bnf"
-    ]
+    ],
+    "allowPaths": [
+      "/classes/",
+      "/functions/",
+      "/internal/",
+      "/ranges/",
+      "/index.js",
+      "/preload.js",
+      "/range.bnf"
+    ],
+    "publish": "true"
   }
 }

--- a/dist/node_modules/semver/ranges/intersects.js
+++ b/dist/node_modules/semver/ranges/intersects.js
@@ -2,6 +2,6 @@ const Range = require('../classes/range')
 const intersects = (r1, r2, options) => {
   r1 = new Range(r1, options)
   r2 = new Range(r2, options)
-  return r1.intersects(r2)
+  return r1.intersects(r2, options)
 }
 module.exports = intersects

--- a/dist/node_modules/semver/ranges/subset.js
+++ b/dist/node_modules/semver/ranges/subset.js
@@ -68,6 +68,9 @@ const subset = (sub, dom, options = {}) => {
   return true
 }
 
+const minimumVersionWithPreRelease = [new Comparator('>=0.0.0-0')]
+const minimumVersion = [new Comparator('>=0.0.0')]
+
 const simpleSubset = (sub, dom, options) => {
   if (sub === dom) {
     return true
@@ -77,9 +80,9 @@ const simpleSubset = (sub, dom, options) => {
     if (dom.length === 1 && dom[0].semver === ANY) {
       return true
     } else if (options.includePrerelease) {
-      sub = [new Comparator('>=0.0.0-0')]
+      sub = minimumVersionWithPreRelease
     } else {
-      sub = [new Comparator('>=0.0.0')]
+      sub = minimumVersion
     }
   }
 
@@ -87,7 +90,7 @@ const simpleSubset = (sub, dom, options) => {
     if (options.includePrerelease) {
       return true
     } else {
-      dom = [new Comparator('>=0.0.0')]
+      dom = minimumVersion
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@jsdevtools/ez-spawn": "^3.0.4",
         "@jsdevtools/ono": "^7.1.3",
         "command-line-args": "^5.1.1",
-        "semver": "^7.3.4"
+        "semver": "^7.4.0"
       },
       "bin": {
         "npm-publish": "bin/npm-publish.js"
@@ -5971,9 +5971,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -11628,9 +11628,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "requires": {
         "lru-cache": "^6.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@jsdevtools/ez-spawn": "^3.0.4",
         "@jsdevtools/ono": "^7.1.3",
+        "@types/semver": "^7.3.13",
         "command-line-args": "^5.1.1",
         "semver": "^7.4.0"
       },
@@ -26,7 +27,6 @@
         "@types/command-line-args": "^5.0.0",
         "@types/mocha": "^8.2.0",
         "@types/node": "^14.14.19",
-        "@types/semver": "^7.3.4",
         "@types/source-map-support": "^0.5.3",
         "@vercel/ncc": "^0.36.1",
         "chai": "^4.2.0",
@@ -820,10 +820,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
-      "dev": true
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "node_modules/@types/source-map-support": {
       "version": "0.5.4",
@@ -7723,10 +7722,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.9",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
-      "dev": true
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "@types/source-map-support": {
       "version": "0.5.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/command-line-args": "^5.0.0",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.19",
-    "@types/semver": "^7.3.4",
     "@types/source-map-support": "^0.5.3",
     "@vercel/ncc": "^0.36.1",
     "chai": "^4.2.0",
@@ -71,6 +70,7 @@
   "dependencies": {
     "@jsdevtools/ez-spawn": "^3.0.4",
     "@jsdevtools/ono": "^7.1.3",
+    "@types/semver": "^7.3.13",
     "command-line-args": "^5.1.1",
     "semver": "^7.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "@jsdevtools/ez-spawn": "^3.0.4",
     "@jsdevtools/ono": "^7.1.3",
     "command-line-args": "^5.1.1",
-    "semver": "^7.3.4"
+    "semver": "^7.4.0"
   }
 }

--- a/test/specs/action/success.spec.js
+++ b/test/specs/action/success.spec.js
@@ -487,7 +487,7 @@ describe("GitHub Action - success tests", () => {
     files.create([
       {
         path: "workspace/subdir/my-lib/package.json",
-        contents: { name: "my-lib", version: "1.0.0-beta" },
+        contents: { name: "my-lib", version: "1.0.1-beta" },
       },
     ]);
 
@@ -510,7 +510,7 @@ describe("GitHub Action - success tests", () => {
       args: ["publish"],
       cwd: join(paths.workspace, "subdir/my-lib"),
       env: { INPUT_TOKEN: "my-secret-token" },
-      stdout: `my-lib 1.0.0-beta${EOL}`,
+      stdout: `my-lib 1.0.1-beta${EOL}`,
     });
 
     let cli = exec.action({
@@ -521,12 +521,12 @@ describe("GitHub Action - success tests", () => {
     });
 
     expect(cli).to.have.stderr("");
-    expect(cli).stdout.to.include("my-lib 1.0.0-beta");
+    expect(cli).stdout.to.include("my-lib 1.0.1-beta");
     expect(cli).stdout.to.include(
-      "📦 Successfully published my-lib v1.0.0-beta to https://registry.npmjs.org/"
+      "📦 Successfully published my-lib v1.0.1-beta to https://registry.npmjs.org/"
     );
-    expect(cli).stdout.to.include("TEST::set-output name=type::prerelease");
-    expect(cli).stdout.to.include("TEST::set-output name=version::1.0.0-beta");
+    expect(cli).stdout.to.include("TEST::set-output name=type::prepatch");
+    expect(cli).stdout.to.include("TEST::set-output name=version::1.0.1-beta");
     expect(cli).stdout.to.include("TEST::set-output name=old-version::1.0.0");
     expect(cli).stdout.to.include("TEST::set-output name=tag::latest");
     expect(cli).stdout.to.include("TEST::set-output name=access::public");

--- a/test/specs/cli/success.spec.js
+++ b/test/specs/cli/success.spec.js
@@ -356,7 +356,7 @@ describe("CLI - success tests", () => {
     files.create([
       {
         path: "workspace/subdir/my-lib/package.json",
-        contents: { name: "my-lib", version: "1.0.0-beta" },
+        contents: { name: "my-lib", version: "1.0.1-beta" },
       },
     ]);
 
@@ -378,15 +378,15 @@ describe("CLI - success tests", () => {
     npm.mock({
       args: ["publish"],
       cwd: join(paths.workspace, "subdir/my-lib"),
-      stdout: `my-lib 1.0.0-beta${EOL}`,
+      stdout: `my-lib 1.0.1-beta${EOL}`,
     });
 
     let cli = exec.cli("subdir/my-lib/package.json");
 
     expect(cli).to.have.stderr("");
-    expect(cli).stdout.to.include("my-lib 1.0.0-beta");
+    expect(cli).stdout.to.include("my-lib 1.0.1-beta");
     expect(cli).stdout.to.include(
-      "📦 Successfully published my-lib v1.0.0-beta to https://registry.npmjs.org/"
+      "📦 Successfully published my-lib v1.0.1-beta to https://registry.npmjs.org/"
     );
     expect(cli).to.have.exitCode(0);
 

--- a/test/specs/lib/success.spec.js
+++ b/test/specs/lib/success.spec.js
@@ -198,7 +198,7 @@ describe("NPM package - success tests", () => {
 
   it("should use the specified NPM token to publish the package", async () => {
     files.create([
-      { path: "workspace/package.json", contents: { name: "my-lib", version: "1.0.0-beta.1" }},
+      { path: "workspace/package.json", contents: { name: "my-lib", version: "1.0.1-beta.1" }},
     ]);
 
     npm.mock({
@@ -219,7 +219,7 @@ describe("NPM package - success tests", () => {
     npm.mock({
       args: ["publish"],
       env: { INPUT_TOKEN: "my-secret-token" },
-      stdout: `my-lib 1.0.0-beta.1${EOL}`,
+      stdout: `my-lib 1.0.1-beta.1${EOL}`,
     });
 
     let results = await npmPublish({
@@ -228,10 +228,10 @@ describe("NPM package - success tests", () => {
     });
 
     expect(results).to.deep.equal({
-      type: "prerelease",
+      type: "prepatch",
       package: "my-lib",
       registry: new URL("https://registry.npmjs.org/"),
-      version: "1.0.0-beta.1",
+      version: "1.0.1-beta.1",
       oldVersion: "1.0.0",
       tag: "latest",
       access: "public",
@@ -365,7 +365,7 @@ describe("NPM package - success tests", () => {
 
   it("should publish a package that's not in the root of the workspace directory", async () => {
     files.create([
-      { path: "workspace/subdir/my-lib/package.json", contents: { name: "my-lib", version: "1.0.0-beta" }},
+      { path: "workspace/subdir/my-lib/package.json", contents: { name: "my-lib", version: "1.0.1-beta" }},
     ]);
 
     npm.mock({
@@ -386,7 +386,7 @@ describe("NPM package - success tests", () => {
     npm.mock({
       args: ["publish"],
       cwd: join(paths.workspace, "subdir/my-lib"),
-      stdout: `my-lib 1.0.0-beta${EOL}`,
+      stdout: `my-lib 1.0.1-beta${EOL}`,
     });
 
     let results = await npmPublish({
@@ -395,10 +395,10 @@ describe("NPM package - success tests", () => {
     });
 
     expect(results).to.deep.equal({
-      type: "prerelease",
+      type: "prepatch",
       package: "my-lib",
       registry: new URL("https://registry.npmjs.org/"),
-      version: "1.0.0-beta",
+      version: "1.0.1-beta",
       oldVersion: "1.0.0",
       tag: "latest",
       access: "public",


### PR DESCRIPTION
The [latest release of semver](https://github.com/npm/node-semver/releases/tag/v7.4.0) fixed a bug where `semver.diff` would erroneously call the difference between `1.0.0` and `1.0.0-prefix` a "prerelease" rather than the correct "major".

Unfortunately, this bug was encoded into a few of our test suite expectations, which started failing when an unrelated package addition caused the semver dependency to lock at a newer version.

This PR:

- Upgrades semver to latest
- Fixes the tests by using better version values
- Changes `@types/semver` from a dev dep to a prod dep, because we re-export the `ReleaseType` interface from semver