### PR TITLE
Add end-to-end test suite

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 lib
+coverage

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,23 @@
+name: Set up Node.js
+description: Install Node.js and development dependencies
+
+inputs:
+  node-version:
+    description: Node.js version to install
+    default: '18'
+  install-command:
+    description: Install command to run
+    default: npm ci
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install Node.js'
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: 'Install development dependencies'
+      shell: bash
+      run: ${{ inputs.install-command }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,20 +4,20 @@ description: Install Node.js and development dependencies
 inputs:
   node-version:
     description: Node.js version to install
-    default: '18'
+    default: "18"
   install-command:
     description: Install command to run
     default: npm ci
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: 'Install Node.js'
+    - name: "Install Node.js"
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm
 
-    - name: 'Install development dependencies'
+    - name: "Install development dependencies"
       shell: bash
       run: ${{ inputs.install-command }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Check action output
         if: steps.action-no-publish.outputs.type != 'nne'
         run: |
-          echo "::error Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
+          echo "::error::Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
           exit 1
 
       - name: Create new version for Action end-to-end test
@@ -172,7 +172,7 @@ jobs:
       - name: Check release output
         if: steps.action-publish.outputs.type != 'patch'
         run: |
-          echo "::error Expected release type to be 'patch', got '${{ steps.action-publish.outputs.type }}'"
+          echo "::error::Expected release type to be 'patch', got '${{ steps.action-publish.outputs.type }}'"
           exit 1
 
   deploy:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,21 +135,21 @@ jobs:
         with:
           node-version: "18"
 
-      - name: Install production dependencies
-        run: npm ci --omit dev
-
       - name: "Download publish artifact"
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact
           path: lib
 
+      - name: Install production dependencies
+        run: npm install . --production
+
       - id: setup
         name: Login to local registry and set up fixture package
         shell: bash
         run: |
           echo "token=$(./e2e/00-login.sh)" >> "$GITHUB_OUTPUT"
-          echo "package=$(./e2e/01-setup-package.sh ./e2e/dummy "@jsdevtools/dummy" "0.0.1")" >> "$GITHUB_OUTPUT"
+          echo "package=$(./e2e/01-setup-package.sh ./e2e/fixture 0.0.1)" >> "$GITHUB_OUTPUT"
 
       - name: Run CLI end-to-end tests
         shell: bash
@@ -160,7 +160,7 @@ jobs:
           ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
           ./e2e/03-verify.sh ${PACKAGE}
           ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
-          ./e2e/01-setup-package.sh ${PACKAGE} "@jsdevtools/dummy" "0.0.2"
+          ./e2e/01-setup-package.sh ${PACKAGE} 0.0.2
           ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
           ./e2e/03-verify.sh ${PACKAGE}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           node-version: "18"
 
-      - name: "Download publish artifact"
+      - name: Download publish artifact
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact
@@ -151,7 +151,7 @@ jobs:
           echo "token=$(./e2e/00-login.sh)" >> "$GITHUB_OUTPUT"
           echo "package=$(./e2e/01-setup-package.sh ./e2e/fixture 0.0.1)" >> "$GITHUB_OUTPUT"
 
-      - name: Run CLI end-to-end tests
+      - name: Run CLI end-to-end test
         shell: bash
         env:
           TOKEN: ${{ steps.setup.outputs.token }}
@@ -164,6 +164,18 @@ jobs:
           ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
           ./e2e/03-verify.sh ${PACKAGE}
 
+      - name: Create new version for Action end-to-end test
+        shell: bash
+        env:
+        run: ./e2e/01-setup-package.sh ${{ steps.setup.outputs.token }} 0.0.3
+
+      - name: Publish with action
+        uses: ./
+        with:
+          registry: http://localhost:4873
+          package: ${{ steps.setup.outputs.package }}/package.json
+          token: ${{ steps.setup.outputs.token }}
+
   deploy:
     if: github.ref == 'refs/heads/master'
     name: Publish to NPM
@@ -175,7 +187,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: "Download publish artifact"
+      - name: Download publish artifact
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,8 +7,9 @@ on:
     tags-ignore:
       - "*"
 
+  # run CI every Monday at 12:25 UTC
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "25 12 * * 1"
 
 jobs:
   lint:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,10 +88,37 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: "Upload publish artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: publish-artifact
+          path: lib
+
   e2e:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: ["build"]
 
     services:
       verdaccio:
@@ -107,6 +134,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "18"
+
+      - name: "Download publish artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: publish-artifact
 
       - id: setup
         name: Login to local registry and set up fixture package
@@ -133,20 +165,16 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: ["lint", "test", "e2e"]
+    needs: ["lint", "test", "build", "e2e"]
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build the code
-        run: npm run build
+      - name: "Download publish artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: publish-artifact
 
       - name: Publish to NPM
         uses: ./

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,7 +166,6 @@ jobs:
 
       - name: Create new version for Action end-to-end test
         shell: bash
-        env:
         run: ./e2e/01-setup-package.sh ${{ steps.setup.outputs.token }} 0.0.3
 
       - name: Publish with action

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -152,7 +152,7 @@ jobs:
           token: ${{ steps.setup.outputs.token }}
 
       - name: Check action output
-        if: steps.action-no-publish.outputs.type != 'none'
+        if: steps.action-no-publish.outputs.type != 'nne'
         run: |
           echo "::error Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
           exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,8 +1,3 @@
-# GitHub Actions workflow
-# https://help.github.com/en/actions/automating-your-workflow-with-github-actions
-# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
-# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions
-
 name: CI-CD
 
 on:
@@ -25,13 +20,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Install Node.js and dependencies
+        uses: ./actions/setup
 
       - name: Run linters
         run: npm run lint
@@ -56,13 +46,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install Node ${{ matrix.node }}
-        uses: actions/setup-node@v3
-        with:
+      - name: Install Node.js ${{ matrix.node }} and dependencies
+        uses: ./actions/setup
           node-version: ${{ matrix.node }}
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Build the code
         run: npm run build
@@ -97,13 +83,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Install Node.js and dependencies
+        uses: ./actions/setup
 
       - name: Build
         run: npm run build
@@ -118,7 +99,7 @@ jobs:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: ["build"]
+    needs: build
 
     services:
       verdaccio:
@@ -130,19 +111,16 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
+      - name: Install Node.js and dependencies
+        uses: ./actions/setup
         with:
-          node-version: "18"
+          install-command: npm install --production
 
       - name: Download publish artifact
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact
           path: lib
-
-      - name: Install production dependencies
-        run: npm install . --production
 
       - id: setup
         name: Login to local registry and set up fixture package
@@ -164,23 +142,48 @@ jobs:
           ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
           ./e2e/03-verify.sh ${PACKAGE}
 
-      - name: Create new version for Action end-to-end test
-        shell: bash
-        run: ./e2e/01-setup-package.sh ${{ steps.setup.outputs.token }} 0.0.3
-
-      - name: Publish with action
+      - id: action-no-publish
+        name: Publish with already published version
         uses: ./
         with:
           registry: http://localhost:4873
           package: ${{ steps.setup.outputs.package }}/package.json
           token: ${{ steps.setup.outputs.token }}
 
+      - name: Check action output
+        if: steps.action-no-publish.outputs.type != 'none'
+        run: |
+          echo "::error Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
+          exit 1
+
+      - name: Create new version for Action end-to-end test
+        shell: bash
+        run: ./e2e/01-setup-package.sh ${{ steps.setup.outputs.package }} 0.0.3
+
+      - id: action-publish
+        name: Publish a new version
+        uses: ./
+        with:
+          registry: http://localhost:4873
+          package: ${{ steps.setup.outputs.package }}/package.json
+          token: ${{ steps.setup.outputs.token }}
+
+      - name: Check release output
+        if: steps.action-publish.outputs.type != 'patch'
+        run: |
+          echo "::error Expected release type to be 'patch', got '${{ steps.action-publish.outputs.type }}'"
+          exit 1
+
   deploy:
     if: github.ref == 'refs/heads/master'
     name: Publish to NPM
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: ["lint", "test", "build", "e2e"]
+    needs:
+      - lint
+      - test
+      - build
+      - e2e
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -152,7 +152,7 @@ jobs:
           token: ${{ steps.setup.outputs.token }}
 
       - name: Check action output
-        if: steps.action-no-publish.outputs.type != 'nne'
+        if: steps.action-no-publish.outputs.type != 'none'
         run: |
           echo "::error::Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
           exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install Node.js ${{ matrix.node }} and dependencies
         uses: ./actions/setup
+        with:
           node-version: ${{ matrix.node }}
 
       - name: Build the code

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: "Upload publish artifact"
+      - name: Upload publish artifact
         uses: actions/upload-artifact@v3
         with:
           name: publish-artifact
@@ -152,7 +152,7 @@ jobs:
           token: ${{ steps.setup.outputs.token }}
 
       - name: Check action output
-        if: steps.action-no-publish.outputs.type != 'none'
+        if: ${{ steps.action-no-publish.outputs.type != 'none' }}
         run: |
           echo "::error::Expected release type to be 'none', got '${{ steps.action-no-publish.outputs.type }}'"
           exit 1
@@ -170,13 +170,13 @@ jobs:
           token: ${{ steps.setup.outputs.token }}
 
       - name: Check release output
-        if: steps.action-publish.outputs.type != 'patch'
+        if: ${{ steps.action-publish.outputs.type != 'patch' }}
         run: |
           echo "::error::Expected release type to be 'patch', got '${{ steps.action-publish.outputs.type }}'"
           exit 1
 
   deploy:
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.ref == 'refs/heads/master' }}
     name: Publish to NPM
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -139,6 +139,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact
+          path: lib
 
       - id: setup
         name: Login to local registry and set up fixture package
@@ -175,6 +176,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: publish-artifact
+          path: lib
 
       - name: Publish to NPM
         uses: ./

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run coverage
 
       - name: Send code coverage results to Coveralls
-        uses: coverallsapp/github-action@v1.1.0
+        uses: coverallsapp/github-action@045a25193560dc194e405657f552faeb6b9433aa
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
@@ -70,7 +70,7 @@ jobs:
     needs: test
     steps:
       - name: Let Coveralls know that all tests have finished
-        uses: coverallsapp/github-action@v1.1.0
+        uses: coverallsapp/github-action@045a25193560dc194e405657f552faeb6b9433aa
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,8 +16,28 @@ on:
     - cron: "0 0 1 * *"
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linters
+        run: npm run lint
+
   test:
-    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    name: Run tests using Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -44,9 +64,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linters
-        run: npm run lint
-
       - name: Build the code
         run: npm run build
 
@@ -71,12 +88,52 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
-  deploy:
-    name: Publish to NPM
-    if: github.ref == 'refs/heads/master'
+  e2e:
+    name: Run end-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: test
+
+    services:
+      verdaccio:
+        image: verdaccio/verdaccio:5
+        ports:
+          - 4873:4873
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - id: setup
+        name: Login to local registry and set up fixture package
+        shell: bash
+        run: |
+          echo "token=$(./e2e/00-login.sh)" >> "$GITHUB_OUTPUT"
+          echo "package=$(./e2e/01-setup-package.sh ./e2e/dummy "@jsdevtools/dummy" "0.0.1")" >> "$GITHUB_OUTPUT"
+
+      - name: Run CLI end-to-end tests
+        shell: bash
+        env:
+          TOKEN: ${{ steps.setup.outputs.token }}
+          PACKAGE: ${{ steps.setup.outputs.package }}
+        run: |
+          ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+          ./e2e/03-verify.sh ${PACKAGE}
+          ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+          ./e2e/01-setup-package.sh ${PACKAGE} "@jsdevtools/dummy" "0.0.2"
+          ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+          ./e2e/03-verify.sh ${PACKAGE}
+
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: ["lint", "test", "e2e"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js and dependencies
-        uses: ./actions/setup
+        uses: ./.github/actions/setup
 
       - name: Run linters
         run: npm run lint
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js ${{ matrix.node }} and dependencies
-        uses: ./actions/setup
+        uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
 
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js and dependencies
-        uses: ./actions/setup
+        uses: ./.github/actions/setup
 
       - name: Build
         run: npm run build
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js and dependencies
-        uses: ./actions/setup
+        uses: ./.github/actions/setup
         with:
           install-command: npm install --production
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Install production dependencies
+        run: npm ci --omit dev
+
       - name: "Download publish artifact"
         uses: actions/download-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ pids
 # Test output
 /.nyc_output
 /coverage
-/e2e/dummy
+/e2e/fixture

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ pids
 # Test output
 /.nyc_output
 /coverage
+/e2e/dummy

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 dist
 lib
+coverage
+.nyc_output
 package-lock.json

--- a/e2e/00-login.sh
+++ b/e2e/00-login.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Login into the registry and extract the auth token
+# Usage: 00-login.sh
+
+set -e
+
+REGISTRY_HOSTNAME="localhost:4873"
+
+registry_url=http://${REGISTRY_HOSTNAME}
+token_matcher='^\/\/'${REGISTRY_HOSTNAME}'\/:_authToken="(.+)"$'
+temporary_dir=${RUNNER_TEMP:-${TMPDIR}}
+npmrc=${temporary_dir}.npmrc-e2e
+
+{
+echo -e "test"
+sleep 1
+echo -e "test"
+} | NPM_CONFIG_USERCONFIG=${npmrc} npm login --registry ${registry_url} > /dev/null 2>&1
+
+echo "DEBUG: wrote config to temporary file: ${npmrc}" 1>&2
+
+npmrc_contents=$(<${npmrc})
+rm -f ${npmrc}
+
+if [[ "${npmrc_contents}" =~ ${token_matcher} ]]; then
+  echo "${BASH_REMATCH[1]}"
+  exit 0
+fi
+
+echo "ERROR: No token found" 1>&2
+exit 1

--- a/e2e/01-setup-package.sh
+++ b/e2e/01-setup-package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Create a package
+# Usage: 01-setup-package.sh <package_directory> <name> <version>
+
+set -e
+
+PACKAGE_SPEC=$1
+PACKAGE_NAME=$2
+PACKAGE_VERSION=$3
+
+package_manifest=${PACKAGE_SPEC}/package.json
+
+echo "{"                                     > ${package_manifest}
+echo "  \"name\": \"${PACKAGE_NAME}\","      >> ${package_manifest}
+echo "  \"version\": \"${PACKAGE_VERSION}\"" >> ${package_manifest}
+echo "}"                                     >> ${package_manifest}
+
+echo "DEBUG: wrote ${package_manifest}" 1>&2
+echo ${PACKAGE_SPEC}

--- a/e2e/01-setup-package.sh
+++ b/e2e/01-setup-package.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# Create a package
-# Usage: 01-setup-package.sh <package_directory> <name> <version>
+# Create a test fixture package
+# Usage: 01-setup-package.sh <package_directory> <version>
 
 set -e
 
 PACKAGE_SPEC=$1
-PACKAGE_NAME=$2
-PACKAGE_VERSION=$3
+PACKAGE_VERSION=$2
 
 package_manifest=${PACKAGE_SPEC}/package.json
 
+mkdir -p ${PACKAGE_SPEC}
+
 echo "{"                                     > ${package_manifest}
-echo "  \"name\": \"${PACKAGE_NAME}\","      >> ${package_manifest}
+echo "  \"name\": \"@jsdevtools/fixture\","  >> ${package_manifest}
 echo "  \"version\": \"${PACKAGE_VERSION}\"" >> ${package_manifest}
 echo "}"                                     >> ${package_manifest}
 

--- a/e2e/01-setup-package.sh
+++ b/e2e/01-setup-package.sh
@@ -11,7 +11,7 @@ package_manifest=${PACKAGE_SPEC}/package.json
 
 mkdir -p ${PACKAGE_SPEC}
 
-echo "{"                                     > ${package_manifest}
+echo "{"                                      > ${package_manifest}
 echo "  \"name\": \"@jsdevtools/fixture\","  >> ${package_manifest}
 echo "  \"version\": \"${PACKAGE_VERSION}\"" >> ${package_manifest}
 echo "}"                                     >> ${package_manifest}

--- a/e2e/02-publish.sh
+++ b/e2e/02-publish.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Publish a package to the registry using the CLI
+# Usage: 02-publish.sh <package_directory> <token>
+
+set -e
+
+REGISTRY_URL="http://localhost:4873"
+PACKAGE_SPEC=$1
+TOKEN=$2
+
+node ./bin/npm-publish --token=${TOKEN} --registry=${REGISTRY_URL} ${PACKAGE_SPEC}/package.json

--- a/e2e/03-verify.sh
+++ b/e2e/03-verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Verify that a package was published
+# Usage: 03-verify.sh <package_directory>
+
+set -e
+
+REGISTRY_URL="http://localhost:4873"
+PACKAGE_SPEC=$1
+
+package_name=$(cd $1 && npm pkg get name | sed 's/"//g')
+package_version=$(cd $1 && npm pkg get version | sed 's/"//g')
+
+npm view $package_name@$package_version

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,44 @@
+# End-to-end tests
+
+This directory contains scripts to run end-to-end tests against a locally running [Verdaccio][] registry.
+
+These test are run automatically in CI, but can be run locally, too.
+
+[Verdaccio]: https://verdaccio.org/
+
+## Usage
+
+### Launch a Verdaccio registry
+
+We use Docker to run a default instance of the Verdaccio server.
+
+```shell
+docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
+```
+
+### Setup
+
+Login to the local registry and create a fixture package.
+
+```shell
+export TOKEN=$(./e2e/00-login.sh)
+export PACKAGE=$(./e2e/01-setup-package.sh ./e2e/dummy "@jsdevtools/dummy" "0.0.1")
+```
+
+### Test the CLI
+
+1. Publish the package to the registry.
+2. Verify the package was published.
+3. Try to publish again, verify publish is skipped.
+4. Create a new version.
+5. Publish the new version.
+6. Verify the new version was published.
+
+```shell
+./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+./e2e/03-verify.sh ${PACKAGE}
+./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+./e2e/01-setup-package.sh ${PACKAGE} "@jsdevtools/dummy" "0.0.2"
+./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
+./e2e/03-verify.sh ${PACKAGE}
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,7 +22,7 @@ Login to the local registry and create a fixture package.
 
 ```shell
 export TOKEN=$(./e2e/00-login.sh)
-export PACKAGE=$(./e2e/01-setup-package.sh ./e2e/dummy "@jsdevtools/dummy" "0.0.1")
+export PACKAGE=$(./e2e/01-setup-package.sh ./e2e/fixture 0.0.1)
 ```
 
 ### Test the CLI
@@ -38,7 +38,7 @@ export PACKAGE=$(./e2e/01-setup-package.sh ./e2e/dummy "@jsdevtools/dummy" "0.0.
 ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
 ./e2e/03-verify.sh ${PACKAGE}
 ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
-./e2e/01-setup-package.sh ${PACKAGE} "@jsdevtools/dummy" "0.0.2"
+./e2e/01-setup-package.sh ${PACKAGE} 0.0.2
 ./e2e/02-publish.sh ${PACKAGE} ${TOKEN}
 ./e2e/03-verify.sh ${PACKAGE}
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib"
   ],
   "scripts": {
-    "clean": "shx rm -rf .nyc_output coverage lib dist",
+    "clean": "shx rm -rf .nyc_output coverage lib dist e2e/fixture",
     "lint": "npm run _eslint && npm run _prettier -- --check",
     "format": "npm run _eslint -- --fix && npm run _prettier -- --write",
     "build": "npm run build:typescript && npm run build:ncc && npm run build:node_modules",


### PR DESCRIPTION
## Overview

This PR adds a [Verdaccio](https://verdaccio.org/)-based end-to-end test suite to CI, which spins up an NPM registry on `localhost` in the runner and tests that:

- The CLI is able to publish a package
- The action is able to publish a package
- The CLI will not publish a package if the version is already published
- The action will not publish a package if the version is already published

These tests run through a lot of the code, which means we get pretty decent bang for our buck, and we can defer a lot of smaller behaviors to isolated unit tests. Most importantly, they only work if our registry auth logic is working, which is probably the most mission-critical logic in the module.

This PR should merge before anything else lands. I've added the E2E status check as a requirement for any PR merging into the main branch.

## Background

The existing test suite of this action can't be used for actual regression protection, because it mocks out the `npm` binary, in the classical sense. Each test forms a set of expected calls to `npm` and return values for each of those calls. If any of those calls doesn't happen, or happens in a different manner than specified, the test fails.

From a development standpoint, this has the following downsides:

- The tests don't tell us if the module actually works
    - Instead, they tell us that the module calls `npm` in the way we think `npm` is supposed to be called
    - We could be wrong about how we're supposed to call `npm`!
- If we change how we call `npm`, the tests will automatically fail, even if the changes are correct
    - That means we can't refactor how we call `npm` without also refactoring the tests
    - Instead of being a stable platform that we develop against, the tests are now just another thing we have to change where we could introduce bugs

## Changes

- Add E2E job to CI, powered by Docker and a few small bash scripts in `./e2e`
- Various CI improvements
    - Run CI weekly rather than monthly
    - Upgrade coveralls action
    - Move common Node.js setup to little composite action
    - Separate linting job from matrixed test job so we don't get duplicate linting warnings
    - Separate build job from publish jobs
    - Make sure E2E tests run against the code that will actually be published (or is committed, in the case of the action) rather than building fresh every time