### PR TITLE
fix: do not suppress E409 from `npm publish`

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -142,7 +142,6 @@ const DIFFERENT = "different";
 const VIEW = "view";
 const PUBLISH = "publish";
 const E404 = "E404";
-const E409 = "E409";
 const EPUBLISHCONFLICT = "EPUBLISHCONFLICT";
 const IS_WINDOWS$1 = os.platform() === "win32";
 const NPM = IS_WINDOWS$1 ? "npm.cmd" : "npm";
@@ -765,7 +764,7 @@ async function compareAndPublish(manifest, options, environment) {
 		errorCode: void 0,
 		error: void 0
 	};
-	if (publishCall.error && publishCall.errorCode !== EPUBLISHCONFLICT && publishCall.errorCode !== E409) throw publishCall.error;
+	if (publishCall.error && publishCall.errorCode !== EPUBLISHCONFLICT) throw publishCall.error;
 	const { successData: publishData } = publishCall;
 	return {
 		id: isDryRun && !comparison.type ? void 0 : publishData?.id,

--- a/src/compare-and-publish/__tests__/compare-and-publish.test.ts
+++ b/src/compare-and-publish/__tests__/compare-and-publish.test.ts
@@ -223,37 +223,34 @@ describe("compareAndPublish", () => {
     await expect(result).rejects.toThrow(errors.NpmCallError);
   });
 
-  it.each(["EPUBLISHCONFLICT", "E409"])(
-    "should allow an %s error from npm publish",
-    async (errorCode) => {
-      when(callNpmCli<"publish">)
-        .calledWith("publish", ["."], {
-          logger,
-          environment,
-          ignoreScripts: false,
-        })
-        .thenResolve({
-          successData: undefined,
-          errorCode,
-          error: new errors.NpmCallError("publish", 1, "oh no"),
-        });
-
-      const result = await subject.compareAndPublish(
-        manifest,
-        normalizedOptions,
-        environment
-      );
-
-      expect(result).toEqual({
-        id: undefined,
-        files: [],
-        oldVersion: "0.0.1",
-        type: undefined,
+  it("should allow an EPUBLISHCONFLICT error from npm publish", async () => {
+    when(callNpmCli<"publish">)
+      .calledWith("publish", ["."], {
+        logger,
+        environment,
+        ignoreScripts: false,
+      })
+      .thenResolve({
+        successData: undefined,
+        errorCode: "EPUBLISHCONFLICT",
+        error: new errors.NpmCallError("publish", 1, "oh no"),
       });
-    }
-  );
 
-  it("should raise a non-EPUBLISHCONFLIG from npm publish", async () => {
+    const result = await subject.compareAndPublish(
+      manifest,
+      normalizedOptions,
+      environment
+    );
+
+    expect(result).toEqual({
+      id: undefined,
+      files: [],
+      oldVersion: "0.0.1",
+      type: undefined,
+    });
+  });
+
+  it("should raise a non-EPUBLISHCONFLICT from npm publish", async () => {
     when(callNpmCli<"publish">)
       .calledWith("publish", ["."], {
         logger,

--- a/src/compare-and-publish/compare-and-publish.ts
+++ b/src/compare-and-publish/compare-and-publish.ts
@@ -2,7 +2,6 @@ import type { NormalizedOptions } from "../normalize-options.js";
 import {
   callNpmCli,
   E404,
-  E409,
   EPUBLISHCONFLICT,
   type NpmCliEnvironment,
   PUBLISH,
@@ -67,11 +66,7 @@ export async function compareAndPublish(
       ? await callNpmCli(PUBLISH, publishArguments, cliOptions)
       : { successData: undefined, errorCode: undefined, error: undefined };
 
-  if (
-    publishCall.error &&
-    publishCall.errorCode !== EPUBLISHCONFLICT &&
-    publishCall.errorCode !== E409
-  ) {
+  if (publishCall.error && publishCall.errorCode !== EPUBLISHCONFLICT) {
     throw publishCall.error;
   }
 

--- a/src/npm/__tests__/call-npm-cli.test.ts
+++ b/src/npm/__tests__/call-npm-cli.test.ts
@@ -13,6 +13,7 @@ describe.concurrent("callNpmCli", () => {
         ignoreScripts: true,
         environment: {
           npm_config_scope: "@cool-scope",
+          npm_config_ignore_scripts: "false",
         },
       });
 
@@ -36,6 +37,7 @@ describe.concurrent("callNpmCli", () => {
         ignoreScripts: false,
         environment: {
           npm_config_scope: "@cool-scope",
+          npm_config_ignore_scripts: "false",
         },
       });
 


### PR DESCRIPTION
Fixes #245 